### PR TITLE
Adds support for custom identity resources and claims

### DIFF
--- a/src/utils/ClaimJsonConverter.cs
+++ b/src/utils/ClaimJsonConverter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Security.Claims;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace OpenIdConnectServer.Utils
+{
+    public class ClaimJsonConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var jObject = JObject.Load(reader);
+            var type = jObject["Type"].Value<string>();
+            var val = jObject["Value"].Value<string>();
+
+            return new Claim(type, val);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Claim);
+        }
+
+        public override bool CanRead => true;
+        public override bool CanWrite => false;
+    }
+}

--- a/src/utils/ClaimJsonConverter.cs
+++ b/src/utils/ClaimJsonConverter.cs
@@ -5,25 +5,21 @@ using Newtonsoft.Json.Linq;
 
 namespace OpenIdConnectServer.Utils
 {
-    public class ClaimJsonConverter : JsonConverter
+    public class ClaimJsonConverter : JsonConverter<Claim>
     {
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, Claim value, JsonSerializer serializer)
         {
             throw new NotSupportedException();
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override Claim ReadJson(JsonReader reader, Type objectType, Claim existingValue, bool hasExistingValue,
+            JsonSerializer serializer)
         {
             var jObject = JObject.Load(reader);
             var type = jObject["Type"].Value<string>();
             var val = jObject["Value"].Value<string>();
 
             return new Claim(type, val);
-        }
-
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(Claim);
         }
 
         public override bool CanRead => true;


### PR DESCRIPTION
Hi, 
Here is a PR with support for custom identity resources and claims. Config could look like:
`USERS_CONFIGURATION_INLINE: |
        [
          {
            "SubjectId":"1",
            "Username":"User1",
            "Password":"pwd",
            "Claims":[{
              "Type": "tenantId",
              "Value": "sp",
            },{
              "Type": "group",
              "Value": "group1",
            },{
              "Type": "group",
              "Value": "group2",
            }]
          }
        ]
      IDENTITY_RESOURCES_INLINE: |
          [
            {
              "Name": "tenant",
              "ClaimTypes": ["tenantId"]
            }, {
              "Name": "roles",
              "ClaimTypes": ["role"]
            }, {
              "Name": "groups",
              "ClaimTypes": ["group"]
            },
          ]`

I'm not sure if such customization should be added to readme example