### PR TITLE
Get test data from oidc config files

### DIFF
--- a/e2e/.env
+++ b/e2e/.env
@@ -1,5 +1,2 @@
 OIDC_TOKEN_URL=http://localhost:8080/connect/token
 OIDC_AUTHORIZE_URL=http://localhost:8080/connect/authorize
-CLIENT_CREDENTIALS_CLIENT_ID=client-credentials-mock-client
-CLIENT_CREDENTIALS_CLIENT_SECRET=client-credentials-mock-client-secret
-API_RESOURCE=some-app-scope-1

--- a/e2e/config/clients-configuration.json
+++ b/e2e/config/clients-configuration.json
@@ -1,45 +1,31 @@
-[{
-  "ClientId": "implicit-mock-client",
-  "Description": "Client for implicit flow",
-  "AllowedGrantTypes": [
-      "implicit"
-  ],
-  "AllowAccessTokensViaBrowser": true,
-  "RedirectUris": [
-      "https://www.google.com"
-  ],
-  "AllowedScopes": [
-      "openid",
-      "profile",
-      "email"
-  ],
-  "IdentityTokenLifetime": 3600,
-  "AccessTokenLifetime": 3600
-},
-{
-  "ClientId": "client-credentials-mock-client",
-  "ClientSecrets": [
-    "client-credentials-mock-client-secret"
-  ],
-  "Description": "Client for client credentials flow",
-  "AllowedGrantTypes": [
-      "client_credentials"
-  ],
-  "AllowedScopes": [
-      "some-app-scope-1"
-  ],
-  "ClientClaimsPrefix": "",
-  "Claims": [
+[
+  {
+    "ClientId": "implicit-flow-client-id",
+    "Description": "Client for implicit flow",
+    "AllowedGrantTypes": ["implicit"],
+    "AllowAccessTokensViaBrowser": true,
+    "RedirectUris": ["https://www.google.com"],
+    "AllowedScopes": ["openid", "profile", "email"],
+    "IdentityTokenLifetime": 3600,
+    "AccessTokenLifetime": 3600
+  },
+  {
+    "ClientId": "client-credentials-mock-client-id",
+    "ClientSecrets": ["client-credentials-mock-client-secret"],
+    "Description": "Client for client credentials flow",
+    "AllowedGrantTypes": ["client_credentials"],
+    "AllowedScopes": ["some-app-scope-1"],
+    "ClientClaimsPrefix": "",
+    "Claims": [
       {
-          "Type": "string_claim",
-          "Value": "string_claim_value"
+        "Type": "string_claim",
+        "Value": "string_claim_value"
       },
       {
-          "Type": "json_claim",
-          "Value": "['value1', 'value2']",
-          "ValueType": "json"
+        "Type": "json_claim",
+        "Value": "['value1', 'value2']",
+        "ValueType": "json"
       }
-  ]
-
-}
+    ]
+  }
 ]

--- a/e2e/tests/__snapshots__/authorization-endpoint.spec.ts.snap
+++ b/e2e/tests/__snapshots__/authorization-endpoint.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`Authorization Endpoint Implicit Flow 1`] = `
   "alg": "RS256",
   "typ": "JWT",
   "iss": "http://localhost:8080",
-  "aud": "implicit-mock-client",
+  "aud": "implicit-flow-client-id",
   "nonce": "xyz",
   "s_hash": "ungWv48Bz-pBQUDeXa4iIw",
   "sub": "1",
@@ -21,7 +21,7 @@ exports[`Authorization Endpoint Implicit Flow 2`] = `
   "alg": "RS256",
   "typ": "JWT",
   "iss": "http://localhost:8080",
-  "client_id": "implicit-mock-client",
+  "client_id": "implicit-flow-client-id",
   "sub": "1",
   "idp": "local",
   "scope": [

--- a/e2e/tests/__snapshots__/token-endpoint.spec.ts.snap
+++ b/e2e/tests/__snapshots__/token-endpoint.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`Token Endpoint Client Credentials 1`] = `
   "typ": "JWT",
   "iss": "http://localhost:8080",
   "aud": "some-app",
-  "client_id": "client-credentials-mock-client",
+  "client_id": "client-credentials-mock-client-id",
   "string_claim": "string_claim_value",
   "scope": [
     "some-app-scope-1"

--- a/e2e/tests/token-endpoint.spec.ts
+++ b/e2e/tests/token-endpoint.spec.ts
@@ -3,18 +3,24 @@ import * as dotenv from 'dotenv';
 import axios from 'axios';
 import { decode } from 'jws';
 
+import clients from '../config/clients-configuration.json';
+import type { Client } from '../types';
+
 describe('Token Endpoint', () => {
+  let client: Client;
+
   beforeAll(() => {
     dotenv.config();
+    client = clients.find(c => c.ClientId === 'client-credentials-mock-client-id');
+    expect(client).toBeDefined();
   });
 
   test('Client Credentials', async () => {
-    const { CLIENT_CREDENTIALS_CLIENT_ID, CLIENT_CREDENTIALS_CLIENT_SECRET, API_RESOURCE } = process.env;
     const parameters = {
-      client_id: CLIENT_CREDENTIALS_CLIENT_ID,
-      client_secret: CLIENT_CREDENTIALS_CLIENT_SECRET,
+      client_id: client.ClientId,
+      client_secret: client.ClientSecrets?.[0],
       grant_type: 'client_credentials',
-      scope: API_RESOURCE,
+      scope: client.AllowedScopes[0],
     };
 
     const response = await axios.post(process.env.OIDC_TOKEN_URL, querystring.stringify(parameters));

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -7,7 +7,10 @@
     "moduleResolution": "node",
     "lib": ["DOM", "es2017"],
     "sourceMap": true,
+    "types": ["jest"],
     "outDir": "./dist",
-    "allowJs": true
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   }
 }

--- a/e2e/types/claim.ts
+++ b/e2e/types/claim.ts
@@ -1,0 +1,5 @@
+export default interface Claim {
+  Type: string;
+  Value: string;
+  ValueType?: string;
+}

--- a/e2e/types/client.ts
+++ b/e2e/types/client.ts
@@ -1,0 +1,15 @@
+import type Claim from './claim';
+
+export default interface Client {
+  ClientId: string;
+  ClientSecrets?: string[];
+  Description?: string;
+  AllowedGrantTypes: string[];
+  AllowedScopes: string[];
+  RedirectUris?: string[];
+  AllowAccessTokensViaBrowser?: boolean;
+  AccessTokenLifetime?: number;
+  IdentityTokenLifetime?: number;
+  Claims?: Claim[];
+  ClientClaimsPrefix?: string;
+}

--- a/e2e/types/index.ts
+++ b/e2e/types/index.ts
@@ -1,0 +1,5 @@
+import Claim from './claim';
+import Client from './client';
+import User from './user';
+
+export { Claim, Client, User };

--- a/e2e/types/user.ts
+++ b/e2e/types/user.ts
@@ -1,0 +1,8 @@
+import type Claim from './claim';
+
+export default interface User {
+  SubjectId: string;
+  Username: string;
+  Password: string;
+  Claims?: Claim[];
+}


### PR DESCRIPTION
Tests will use client and user values from oidc server configuration files instead of the values being written hardcoded in the test suites.