### PR TITLE
Fix double checks run for PR

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,14 @@
 name: Run Tests
 
-on: [push, pull_request_target]
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - README.md
+  pull_request_target:
+    paths-ignore:
+      - README.md
 
 jobs:
   tests:


### PR DESCRIPTION
Fire `pull_request_target` trigger for PRs and `push` trigger for pushed commits to `master` branch