### PR TITLE
Use linux line endings for *.sh files to fix docker build on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
I tried to build the docker container on windows and got an error running getmain.sh:

```
 => ERROR [source  5/10] RUN ./getmain.sh
------
> [source  5/10] RUN ./getmain.sh:
#12 0.217 /usr/bin/env: 'bash\r': No such file or directory
------
executor failed running [/bin/sh -c ./getmain.sh]: exit code: 127
```

Using linux line endings for *.sh fixes. 