### PR TITLE
Use new path in registry for dotnet images

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.17 as source
+FROM mcr.microsoft.com/dotnet/sdk:3.1.411 as source
 ARG target="Release"
 
 RUN apt-get update && apt-get install unzip
@@ -19,7 +19,7 @@ RUN dotnet publish -c $target -o obj/docker/publish
 RUN cp -r /src/obj/docker/publish /OpenIdConnectServerMock
 
 # Stage 2: Release
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 as release
+FROM mcr.microsoft.com/dotnet/aspnet:3.1.17 as release
 ARG target="Release"
 
 RUN if [ $target = "Debug" ]; then apt-get update && apt-get install unzip && rm -rf /var/lib/apt/lists/* && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg; fi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM mcr.microsoft.com/dotnet/sdk:3.1.411 as source
+FROM mcr.microsoft.com/dotnet/sdk:3.1 as source
 ARG target="Release"
 
 RUN apt-get update && apt-get install unzip
@@ -19,7 +19,7 @@ RUN dotnet publish -c $target -o obj/docker/publish
 RUN cp -r /src/obj/docker/publish /OpenIdConnectServerMock
 
 # Stage 2: Release
-FROM mcr.microsoft.com/dotnet/aspnet:3.1.17 as release
+FROM mcr.microsoft.com/dotnet/aspnet:3.1 as release
 ARG target="Release"
 
 RUN if [ $target = "Debug" ]; then apt-get update && apt-get install unzip && rm -rf /var/lib/apt/lists/* && curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg; fi

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as source
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.17 as source
 ARG target="Release"
 
 RUN apt-get update && apt-get install unzip


### PR DESCRIPTION
There are 3 high severity vulnerabilities reported to debian and this upgrade will include the patched debian base

Below are the CVE's of those vulnerabilities

[CVE-2021-33574](https://security-tracker.debian.org/tracker/CVE-2021-33574)
[CVE-2019-25013](https://security-tracker.debian.org/tracker/CVE-2019-25013)
[CVE-2021-3520](https://security-tracker.debian.org/tracker/CVE-2021-3520)

