### PR TITLE
ci: build Docker image for arm64 to support Mac M1 chips

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -28,12 +28,19 @@ jobs:
         with:
           string: ${{ github.repository_owner }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build and push new docker image
         uses: docker/build-push-action@v2
         with:
           push: true
           context: ./src
           file: ./src/Dockerfile
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock:latest
             ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock:${{ steps.get_version.outputs.version-without-v }}


### PR DESCRIPTION
Running the image on an M1-based Mac gives the following error. This appears to be due to missing libraries in Docker's amd64 emulation. When I cloned the repo and ran `docker build` manually, the image worked like a charm.

I've tweaked the `tag` workflow to include the following two actions:
- https://github.com/marketplace/actions/docker-setup-qemu
- https://github.com/marketplace/actions/docker-setup-buildx#with-qemu

They are both Docker official actions so should be reasonably well supported along with the existing `docker/build-push-action` action.

```
Unhandled exception. System.IO.IOException: Function not implemented
   at System.IO.FileSystemWatcher.StartRaisingEvents()
   at System.IO.FileSystemWatcher.StartRaisingEventsIfNotDisposed()
   at System.IO.FileSystemWatcher.set_EnableRaisingEvents(Boolean value)
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.TryEnableFileSystemWatcher()
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.CreateFileChangeToken(String filter)
   at Microsoft.Extensions.FileProviders.PhysicalFileProvider.Watch(String filter)
   at Microsoft.Extensions.Configuration.FileConfigurationProvider.<.ctor>b__1_0()
   at Microsoft.Extensions.Primitives.ChangeToken.OnChange(Func`1 changeTokenProducer, Action changeTokenConsumer)
   at Microsoft.Extensions.Configuration.FileConfigurationProvider..ctor(FileConfigurationSource source)
   at Microsoft.Extensions.Configuration.Json.JsonConfigurationSource.Build(IConfigurationBuilder builder)
   at Microsoft.Extensions.Configuration.ConfigurationBuilder.Build()
   at Microsoft.AspNetCore.Hosting.WebHostBuilder.BuildCommonServices(AggregateException& hostingStartupErrors)
   at Microsoft.AspNetCore.Hosting.WebHostBuilder.Build()
   at OpenIdConnectServer.Program.BuildWebHost(String[] args) in /src/Program.cs:line 27
   at OpenIdConnectServer.Program.Main(String[] args) in /src/Program.cs:line 23
qemu: uncaught target signal 6 (Aborted) - core dumped
```