### PR TITLE
docs(README): update clients-config.json snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,23 +64,28 @@ services:
             "Claims": [
               {
                 "Type": "name",
-                "Value": "Sam Tailor"
+                "Value": "Sam Tailor",
+                "ValueType": "string"
               },
               {
                 "Type": "email",
-                "Value": "sam.tailor@gmail.com"
+                "Value": "sam.tailor@gmail.com",
+                "ValueType": "string"
               },
               {
                 "Type": "some-api-resource-claim",
-                "Value": "Sam's Api Resource Custom Claim"
+                "Value": "Sam's Api Resource Custom Claim",
+                "ValueType": "string"
               },
               {
                 "Type": "some-api-scope-claim",
-                "Value": "Sam's Api Scope Custom Claim"
+                "Value": "Sam's Api Scope Custom Claim",
+                "ValueType": "string"
               },
               {
                 "Type": "some-identity-resource-claim",
-                "Value": "Sam's Identity Resource Custom Claim"
+                "Value": "Sam's Identity Resource Custom Claim",
+                "ValueType": "string"
               }
             ]
           }
@@ -109,16 +114,17 @@ When `clients-config.json` is as following:
     "ClientSecrets": ["client-credentials-mock-client-secret"],
     "Description": "Client for client credentials flow",
     "AllowedGrantTypes": ["client_credentials"],
-    "AllowedScopes": ["some-app"],
+    "AllowedScopes": ["some-app-scope-1"],
     "ClientClaimsPrefix": "",
     "Claims": [
       {
         "Type": "string_claim",
-        "Value": "string_claim_value"
+        "Value": "string_claim_value",
+        "ValueType": "string"
       },
       {
         "Type": "json_claim",
-        "Value": "['value1', 'value2']",
+        "Value": "[\"value1\", \"value2\"]",
         "ValueType": "json"
       }
     ]

--- a/e2e/config/clients.json
+++ b/e2e/config/clients.json
@@ -44,7 +44,7 @@
       },
       {
         "Type": "json_claim",
-        "Value": "['value1', 'value2']",
+        "Value": "[\"value1\", \"value2\"]",
         "ValueType": "json"
       }
     ],


### PR DESCRIPTION
This MR fixes some typos for the `clients-config.json` snippet in `README.md` (and the e2e config).
As is, the `clients-config.json` snippet is invalid and/or the server returns a `500 Internal Server` error:

<details>
  <summary>Server logs</summary>

  ```sh
[15:06:39 Error] Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware
An unhandled exception has occurred while executing the request.
System.Text.Json.JsonException: ''' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 1.
 ---> System.Text.Json.JsonReaderException: ''' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 1.
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException(Utf8JsonReader& json, ExceptionResource resource, Byte nextByte, ReadOnlySpan`1 bytes)
   at System.Text.Json.Utf8JsonReader.ConsumeValue(Byte marker)
   at System.Text.Json.Utf8JsonReader.ReadSingleSegment()
   at System.Text.Json.Utf8JsonReader.Read()
   at System.Text.Json.Utf8JsonReader.TrySkip()
   at System.Text.Json.JsonDocument.TryParseValue(Utf8JsonReader& reader, JsonDocument& document, Boolean shouldThrow, Boolean useArrayPools)
   at System.Text.Json.Serialization.Converters.JsonElementConverter.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, JsonReaderException ex)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 utf8Json, JsonTypeInfo jsonTypeInfo, Nullable`1 actualByteCount)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 json, JsonTypeInfo jsonTypeInfo)
   at System.Text.Json.JsonSerializer.Deserialize[TValue](String json, JsonSerializerOptions options)
   at Duende.IdentityServer.Extensions.TokenExtensions.AddObject(Claim claim) in /_/src/IdentityServer/Extensions/TokenExtensions.cs:line 158
   at Duende.IdentityServer.Extensions.TokenExtensions.CreateJwtPayloadDictionary(Token token, IdentityServerOptions options, ISystemClock clock, ILogger logger) in /_/src/IdentityServer/Extensions/TokenExtensions.cs:line 112
   at Duende.IdentityServer.Services.DefaultTokenCreationService.CreatePayloadAsync(Token token) in /_/src/IdentityServer/Services/Default/DefaultTokenCreationService.cs:line 87
   at Duende.IdentityServer.Services.DefaultTokenCreationService.CreateTokenAsync(Token token) in /_/src/IdentityServer/Services/Default/DefaultTokenCreationService.cs:line 74
   at Duende.IdentityServer.Services.DefaultTokenService.CreateSecurityTokenAsync(Token token) in /_/src/IdentityServer/Services/Default/DefaultTokenService.cs:line 275
   at Duende.IdentityServer.ResponseHandling.TokenResponseGenerator.CreateAccessTokenAsync(ValidatedTokenRequest request) in /_/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs:line 494
   at Duende.IdentityServer.ResponseHandling.TokenResponseGenerator.ProcessTokenRequestAsync(TokenRequestValidationResult validationResult) in /_/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs:line 393
   at Duende.IdentityServer.ResponseHandling.TokenResponseGenerator.ProcessAsync(TokenRequestValidationResult request) in /_/src/IdentityServer/ResponseHandling/Default/TokenResponseGenerator.cs:line 96
   at Duende.IdentityServer.Endpoints.TokenEndpoint.ProcessTokenRequestAsync(HttpContext context) in /_/src/IdentityServer/Endpoints/TokenEndpoint.cs:line 110
   at Duende.IdentityServer.Endpoints.TokenEndpoint.ProcessAsync(HttpContext context) in /_/src/IdentityServer/Endpoints/TokenEndpoint.cs:line 76
   at Duende.IdentityServer.Hosting.IdentityServerMiddleware.Invoke(HttpContext context, IEndpointRouter router, IUserSession userSession, IEventService events, IIssuerNameService issuerNameService, ISessionCoordinationService sessionCoordinationService) in /_/src/IdentityServer/Hosting/IdentityServerMiddleware.cs:line 98
   at Duende.IdentityServer.Hosting.IdentityServerMiddleware.Invoke(HttpContext context, IEndpointRouter router, IUserSession userSession, IEventService events, IIssuerNameService issuerNameService, ISessionCoordinationService sessionCoordinationService) in /_/src/IdentityServer/Hosting/IdentityServerMiddleware.cs:line 113
   at Duende.IdentityServer.Hosting.MutualTlsEndpointMiddleware.Invoke(HttpContext context, IAuthenticationSchemeProvider schemes) in /_/src/IdentityServer/Hosting/MutualTlsEndpointMiddleware.cs:line 94
   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
   at Duende.IdentityServer.Hosting.DynamicProviders.DynamicSchemeAuthenticationMiddleware.Invoke(HttpContext context) in /_/src/IdentityServer/Hosting/DynamicProviders/DynamicSchemes/DynamicSchemeAuthenticationMiddleware.cs:line 47
   at Duende.IdentityServer.Hosting.BaseUrlMiddleware.Invoke(HttpContext context) in /_/src/IdentityServer/Hosting/BaseUrlMiddleware.cs:line 27
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)
  ```
</details>

This was a leftover after https://github.com/Soluto/oidc-server-mock/pull/115.
[`e2e/config/clients.json`](https://github.com/Soluto/oidc-server-mock/pull/115/files#diff-3451977678218796a7390f9e6de6742042c4ae07ab7f088dc982658b75c1646a) was correctly updated back then.

:hammer_and_wrench: with :heart: by [Siemens](https://opensource.siemens.com/)