### PR TITLE
Make a dotnet tool package

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,11 +1,11 @@
-name: Build and push new image version
+name: Build and push new version
 
 on:
   create:
 
 jobs:
-  build_push:
-    name: Build and Push
+  build_push_docker:
+    name: Build and Push Docker image
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
@@ -46,3 +46,45 @@ jobs:
             ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock:${{ steps.get_version.outputs.version-without-v }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
+
+  build_push_nuget:
+    name: Build and Push Nuget package
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    defaults:
+      run:
+        working-directory: src
+    env:
+      NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      dotnet-version: "7.0"
+      ui-url: https://raw.githubusercontent.com/DuendeSoftware/IdentityServer.Quickstart.UI/main/getmain.sh
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download UI
+        run: curl -L ${{ env.ui-url }} | bash
+
+      - name: Setup .NET Core SDK ${{ env.dotnet-version }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.dotnet-version }}
+          source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+
+      - name: Install dependencies
+        run: dotnet restore
+
+      - id: get_version
+        name: Format nuget package version
+        uses: battila7/get-version-action@v2
+
+      - name: Build Nuget package
+        run: |
+          dotnet pack --no-restore --configuration Release \
+            /p:VersionPrefix=${{ steps.get_version.outputs.version-without-v }} \
+            /p:RepositoryCommit=${{ github.sha }}
+
+      - name: Push Nuget package
+        run: dotnet nuget push bin/Release/*.nupkg -k ${{ env.NUGET_AUTH_TOKEN }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,8 +15,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.ORG_CR_WRITER_USER }}
-          password: ${{ secrets.ORG_CR_WRITER_PASSWORD }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: get_version
         name: Format docker image tag

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ obj
 # UI
 src/Pages
 src/wwwroot
+
+# Runtime data
+keys
+tempkey.jwk

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -4,5 +4,8 @@ obj/
 Pages
 wwwroot
 
+keys/
+tempkey.jwk
+
 Dockerfile
 .dockerignore

--- a/src/OpenIdConnectServerMock.csproj
+++ b/src/OpenIdConnectServerMock.csproj
@@ -5,6 +5,18 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+
+    <IsPackable>true</IsPackable>
+    <Description>Configurable mock server with OpenId Connect functionality</Description>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <PackageProjectUrl>https://github.com/Soluto/oidc-server-mock</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageTags>OIDC</PackageTags>
+    <RepositoryUrl>https://github.com/Soluto/oidc-server-mock</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>oidc-mock</ToolCommandName>
+    <IncludeContentInPack>false</IncludeContentInPack>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenIdConnectServerMock.csproj
+++ b/src/OpenIdConnectServerMock.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Remove="keys\**" />
     <Content Remove="wwwroot\**" />
     <EmbeddedResource Include="wwwroot\**" />
   </ItemGroup>

--- a/src/OpenIdConnectServerMock.csproj
+++ b/src/OpenIdConnectServerMock.csproj
@@ -4,15 +4,18 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\" />
+    <Content Remove="wwwroot\**" />
+    <EmbeddedResource Include="wwwroot\**" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Duende.IdentityServer" Version="6.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="YamlDotNet" Version="12.0.2" />
   </ItemGroup>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Duende.IdentityServer.Hosting;
+using Microsoft.Extensions.FileProviders;
 using OpenIdConnectServer;
 using OpenIdConnectServer.Helpers;
 using OpenIdConnectServer.JsonConverters;
@@ -67,14 +68,20 @@ app.UseIdentityServer();
 var basePath = Config.GetAspNetServicesOptions().BasePath;
 if (!string.IsNullOrEmpty(basePath))
 {
-    app.UseWhen(ctx => ctx.Request.Path.StartsWithSegments(basePath), appBuilder => {
+    app.UseWhen(ctx => ctx.Request.Path.StartsWithSegments(basePath), appBuilder =>
+    {
         appBuilder.UseMiddleware<BasePathMiddleware>();
         appBuilder.UseMiddleware<IdentityServerMiddleware>();
     });
 }
 
 app.UseHttpsRedirection();
-app.UseStaticFiles();
+
+var manifestEmbeddedProvider = new ManifestEmbeddedFileProvider(typeof(Program).Assembly, "wwwroot");
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = manifestEmbeddedProvider
+});
 
 app.UseRouting();
 


### PR DESCRIPTION
Create a nuget package with a dotnet tool. This will allow users to easily install it [globally](https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-use):
```
dotnet tool install --global OpenIdConnectServerMock
```
or [inside a project](https://learn.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use):
```
dotnet new tool-manifest
dotnet tool install OpenIdConnectServerMock
```
and use it from command line (with the config env variables set):
```
dotnet tool run oidc-mock
```

I would like to see this published on the main https://nuget.org/ feed, but that's up to you to decide.