### PR TITLE
forwarded headers configuration updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ services:
           }
         ]
       CLIENTS_CONFIGURATION_PATH: /tmp/config/clients-config.json
+      ASPNET_SERVICES_OPTIONS_INLINE: |
+        { 
+          "ForwardedHeadersOptions": { 
+            "ForwardedHeaders" : "All"
+          }
+        }
     volumes:
       - .:/tmp/config:ro
 ```

--- a/src/Helpers/AspNetServicesHelper.cs
+++ b/src/Helpers/AspNetServicesHelper.cs
@@ -45,6 +45,8 @@ namespace OpenIdConnectServer.Helpers
 
             if (config.ForwardedHeadersOptions != null)
             {
+                config.ForwardedHeadersOptions.KnownNetworks.Clear();
+                config.ForwardedHeadersOptions.KnownProxies.Clear();
                 app.UseForwardedHeaders(config.ForwardedHeadersOptions);
             }
         }


### PR DESCRIPTION
Hello,

When deploying oidc-server-mock in GCP I faced a problem with .well-known/opeinid-configuration page rendering urls with http, not https schema. This is happening because of SSL offloading happening on proxy and requests reaching container with plain http. This is usually solved with ForwardedHeaders middleware. 
The problem that i faced further is that in KnownNetworks and KnownProxies by default are initialized with loopback records
https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/HttpOverrides/src/ForwardedHeadersOptions.cs#L68-L73
And there are no public setters so it is not possible to override these values in environment variable
In my case clearing these collections is enough. I assume it is likely to be acceptable for most of users because oidc-server-mock is not supposed to be used in prod. 
If you think this is a not acceptable breaking change i would like to discuss how to change configuration because additional property seem to be needed.
I also added an example on how to override ASPNET_SERVICES_OPTIONS_INLINE because it took me some time to check codebase and realise it is possible