### PR TITLE
chore: use pathBase middleware

### DIFF
--- a/e2e/tests/__snapshots__/base-path.spec.ts.snap
+++ b/e2e/tests/__snapshots__/base-path.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Base path Discovery Endpoint 1`] = `
+{
+  "access-control-allow-origin": "https://google.com",
+  "content-type": "application/json; charset=UTF-8",
+  "date": Any<String>,
+  "server": "Kestrel",
+  "transfer-encoding": "chunked",
+}
+`;

--- a/e2e/tests/base-path.spec.ts
+++ b/e2e/tests/base-path.spec.ts
@@ -13,10 +13,15 @@ describe('Base path', () => {
   });
 
   test('Discovery Endpoint', async () => {
-    const response = await fetch(oidcDiscoveryEndpointWithBasePath);
+    const response = await fetch(oidcDiscoveryEndpointWithBasePath, {
+      headers: {
+        origin: 'https://google.com',
+      },
+    });
     expect(response.ok).toBe(true);
     const result = (await response.json()) as unknown;
     expect(result).toHaveProperty('token_endpoint', oidcTokenUrlWithBasePath.href);
+    expect(Object.fromEntries(response.headers.entries())).toMatchSnapshot({ date: expect.any(String) });
   });
 
   test('Token Endpoint', async () => {

--- a/src/Helpers/AspNetServicesHelper.cs
+++ b/src/Helpers/AspNetServicesHelper.cs
@@ -6,19 +6,19 @@ namespace OpenIdConnectServer.Helpers
 {
     public class AspNetServicesOptions
     {
-        public AspNetCorsOptions Cors { get; set; }
+        public AspNetCorsOptions? Cors { get; set; }
 
-        public IDictionary<string, AuthenticationOptions> Authentication { get; set; }
-        public SessionOptions Session { get; set; }
+        public IDictionary<string, AuthenticationOptions>? Authentication { get; set; }
+        public SessionOptions? Session { get; set; }
 
-        public ForwardedHeadersOptions ForwardedHeadersOptions { get; set; }
+        public ForwardedHeadersOptions? ForwardedHeadersOptions { get; set; }
 
-        public string BasePath { get; set; }
+        public string? BasePath { get; set; }
     }
 
     public class AuthenticationOptions
     {
-        public CookieAuthenticationOptions CookieAuthenticationOptions { get; set; }
+        public CookieAuthenticationOptions? CookieAuthenticationOptions { get; set; }
     }
 
     public static class AspNetServicesHelper

--- a/src/OpenIdConnectServerMock.csproj
+++ b/src/OpenIdConnectServerMock.csproj
@@ -8,7 +8,7 @@
 
     <IsPackable>true</IsPackable>
     <Description>Configurable mock server with OpenId Connect functionality</Description>
-    <VersionPrefix>0.10.1</VersionPrefix>
+    <VersionPrefix>0.11.1</VersionPrefix>
     <PackageProjectUrl>https://github.com/Soluto/oidc-server-mock</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>OIDC</PackageTags>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -53,6 +53,7 @@ builder.Services
 
 var app = builder.Build();
 
+app.UsePathBase(Config.GetAspNetServicesOptions().BasePath);
 
 var aspNetServicesOptions = Config.GetAspNetServicesOptions();
 AspNetServicesHelper.ConfigureAspNetServices(builder.Services, aspNetServicesOptions);
@@ -65,16 +66,6 @@ app.UseDeveloperExceptionPage();
 
 app.UseIdentityServer();
 
-var basePath = Config.GetAspNetServicesOptions().BasePath;
-if (!string.IsNullOrEmpty(basePath))
-{
-    app.UseWhen(ctx => ctx.Request.Path.StartsWithSegments(basePath), appBuilder =>
-    {
-        appBuilder.UseMiddleware<BasePathMiddleware>();
-        appBuilder.UseMiddleware<IdentityServerMiddleware>();
-    });
-}
-
 app.UseHttpsRedirection();
 
 var manifestEmbeddedProvider = new ManifestEmbeddedFileProvider(typeof(Program).Assembly, "wwwroot");
@@ -84,13 +75,8 @@ app.UseStaticFiles(new StaticFileOptions
 });
 
 app.UseRouting();
-
 app.UseAuthorization();
-app.UseEndpoints(endpoints =>
-    {
-        endpoints.MapDefaultControllerRoute();
-    });
-
+app.MapDefaultControllerRoute();
 app.MapRazorPages();
 
 app.Run();


### PR DESCRIPTION
Using [`PathBase`](https://github.com/DuendeSoftware/IdentityServer/blob/1ef386a7ab82cad5be4faac1d47155a626f43609/src/IdentityServer/Configuration/IdentityServerApplicationBuilderExtensions.cs#L41) middleware from Duendo

Based on #168 . 