### PR TITLE
fix(ci): replace on:create trigger with on:push:tags in tag.yaml

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,7 +1,9 @@
 name: Build and push new version
 
 on:
-  create:
+  push:
+    tags:
+      - 'v*'
 
 env:
   TILT_VERSION: 'v0.34.2'
@@ -9,7 +11,6 @@ env:
 jobs:
   build_push_docker:
     name: Build and Push Docker image
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,7 +83,6 @@ jobs:
 
   build_push_nuget:
     name: Build and Push Nuget package
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
The release workflow's `on: create` trigger fires on every branch creation (not just tag creation), wasting GitHub Actions quota and cluttering run history with no-op runs. Replacing it with `on: push: tags: ['v*']` ensures the workflow only runs on version-tag pushes; the now-redundant per-job `if` guards are removed. No behavioral change on the release path — all existing `v*` tags continue to trigger both build jobs as before. Verification is post-merge: a branch push must produce zero runs, a `v*` tag push exactly one.

Closes #194
