### PR TITLE
chore: remove redundant pretty-quick from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged
-npx pretty-quick --staged

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "lint-staged": "^15.5.1",
     "prettier": "^3.5.3",
     "prettier-plugin-packagejson": "^2.5.10",
-    "pretty-quick": "^4.1.1",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.31.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       prettier-plugin-packagejson:
         specifier: ^2.5.10
         version: 2.5.10(prettier@3.5.3)
-      pretty-quick:
-        specifier: ^4.1.1
-        version: 4.1.1(prettier@3.5.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1878,11 +1875,6 @@ packages:
       { integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw== }
     engines: { node: '>= 4' }
 
-  ignore@7.0.4:
-    resolution:
-      { integrity: sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A== }
-    engines: { node: '>= 4' }
-
   import-fresh@3.3.0:
     resolution:
       { integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw== }
@@ -2525,11 +2517,6 @@ packages:
     resolution:
       { integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA== }
 
-  mri@1.2.0:
-    resolution:
-      { integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA== }
-    engines: { node: '>=4' }
-
   ms@2.1.3:
     resolution:
       { integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA== }
@@ -2791,14 +2778,6 @@ packages:
     resolution:
       { integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ== }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
-
-  pretty-quick@4.1.1:
-    resolution:
-      { integrity: sha512-9Ud0l/CspNTmyIdYac9X7Inb3o8fuUsw+1zJFvCGn+at0t1UwUcUdo2RSZ41gcmfLv1fxgWQxWEfItR7CBwugg== }
-    engines: { node: '>=14' }
-    hasBin: true
-    peerDependencies:
-      prettier: ^3.0.0
 
   process-on-spawn@1.1.0:
     resolution:
@@ -5125,8 +5104,6 @@ snapshots:
 
   ignore@5.3.1: {}
 
-  ignore@7.0.4: {}
-
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -5813,8 +5790,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mri@1.2.0: {}
-
   ms@2.1.3: {}
 
   natural-compare@1.4.0: {}
@@ -6010,17 +5985,6 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
-
-  pretty-quick@4.1.1(prettier@3.5.3):
-    dependencies:
-      find-up: 5.0.0
-      ignore: 7.0.4
-      mri: 1.2.0
-      picocolors: 1.1.1
-      picomatch: 4.0.2
-      prettier: 3.5.3
-      tinyexec: 0.3.2
-      tslib: 2.8.1
 
   process-on-spawn@1.1.0:
     dependencies:


### PR DESCRIPTION
The pre-commit hook was running Prettier twice on every commit: once through `lint-staged` (which already invokes `prettier --write` for all managed file types) and again via `pretty-quick --staged`. Removing the redundant `pretty-quick` call halves the pre-commit formatting time with no behavioural change.

The `pretty-quick` devDependency is also removed since nothing else in the project references it. The lockfile diff is large because pnpm 10.10 also normalises `resolution` blocks to single-line form; only `pretty-quick`, `mri`, and `ignore` are actually dropped.

Closes #185