### PR TITLE
chore(ci): cache Tilt binary instead of curl-piped install

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TILT_VERSION: 'v0.34.2'
+  TILT_VERSION: '0.34.2'
 
 jobs:
   tests:
@@ -21,8 +21,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Tilt
-        run: curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/${TILT_VERSION}/scripts/install.sh | bash
+      - name: Cache Tilt binary
+        id: cache-tilt
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/tilt
+          key: tilt-${{ runner.os }}-${{ env.TILT_VERSION }}  # arch assumed x86_64; update key if ARM runners added
+
+      - name: Install Tilt
+        if: steps.cache-tilt.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/bin
+          curl -fsSL "https://github.com/tilt-dev/tilt/releases/download/v${TILT_VERSION}/tilt.${TILT_VERSION}.linux.x86_64.tar.gz" \
+            | tar -xz -C ~/.local/bin tilt
+
+      - name: Add Tilt to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  TILT_VERSION: 'v0.34.2'
+  TILT_VERSION: '0.34.2'
 
 jobs:
   build_push_docker:
@@ -46,8 +46,22 @@ jobs:
           file: ./src/Dockerfile
           tags: ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock:${{ steps.get_version.outputs.version-without-v }}-test
 
-      - name: Setup Tilt
-        run: curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/${TILT_VERSION}/scripts/install.sh | bash
+      - name: Cache Tilt binary
+        id: cache-tilt
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/tilt
+          key: tilt-${{ runner.os }}-${{ env.TILT_VERSION }}  # arch assumed x86_64; update key if ARM runners added
+
+      - name: Install Tilt
+        if: steps.cache-tilt.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.local/bin
+          curl -fsSL "https://github.com/tilt-dev/tilt/releases/download/v${TILT_VERSION}/tilt.${TILT_VERSION}.linux.x86_64.tar.gz" \
+            | tar -xz -C ~/.local/bin tilt
+
+      - name: Add Tilt to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/e2e/tests/custom-endpoints/user-management.spec.ts
+++ b/e2e/tests/custom-endpoints/user-management.spec.ts
@@ -100,15 +100,15 @@ describe('User management', () => {
       sub: expect.any(String),
       name: expect.any(String),
       email: expect.any(String),
-      ['some-custom-identity-user-claim']: expect.any(String) as unknown,
+      ['some-custom-identity-user-claim']: expect.any(String),
     });
   }, 10000);
 
   test('Introspection Endpoint', async () => {
     await introspectEndpoint(token, 'some-app', {
       sub: expect.any(String),
-      ['some-app-user-custom-claim']: expect.any(String) as unknown,
-      ['some-app-scope-1-custom-user-claim']: expect.any(String) as unknown,
+      ['some-app-user-custom-claim']: expect.any(String),
+      ['some-app-scope-1-custom-user-claim']: expect.any(String),
     });
   });
 });


### PR DESCRIPTION
On every CI run both pr.yaml and tag.yaml re-download Tilt by piping a master-pinned install script into bash, adding latency and exposing the pipeline to supply-chain changes. This change replaces that pattern with a versioned tarball download (pinned to the GitHub release URL) cached via actions/cache@v4, so cache-hit runs skip the download entirely. The TILT_VERSION env var is normalised to strip its leading v, and a defensive PATH export step ensures the binary is reachable regardless of runner image defaults.

Closes #196