### PR TITLE
fix(lint): use globals.node instead of globals.browser in ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ export default tseslint.config(
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: globals.node,
       parserOptions: {
         project: ['./tsconfig.json'],
         tsconfigRootDir: import.meta.dirname,


### PR DESCRIPTION
The ESLint config declared `globals.browser` as the language environment for a codebase that runs entirely in Node.js (Jest + Playwright Node-side API). This misalignment means the declared globals set does not accurately reflect the runtime, which would cause incorrect results if `no-undef` is ever enabled. Switching to `globals.node` corrects the semantic mismatch.

Closes #187
