### PR TITLE
fix(config): align tsconfig module/moduleResolution with ESM package type

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,12 @@
   "compilerOptions": {
     "baseUrl": "./",
     "esModuleInterop": true,
-    "module": "commonjs",
-    "moduleResolution": "node",
+    // "Bundler" resolution is used instead of "NodeNext" because this project never runs
+    // tsc-emitted JS through Node directly — ts-jest transpiles independently at test time
+    // and there is no tsc build step. If a Node-consumed build is ever added, migrate to
+    // "NodeNext" with explicit .js import extensions and with { type: "json" } on JSON imports.
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "outDir": "./dist",
     "resolveJsonModule": true,
     "rootDir": ".",


### PR DESCRIPTION
The root `tsconfig.json` declared `"module": "commonjs"` / `"moduleResolution": "node"` while `package.json` uses `"type": "module"` (ESM). This caused `tsc --noEmit` and type-aware ESLint to reason about imports as CommonJS, producing misleading diagnostics and masking real ESM-specific issues.

Updated to `"module": "ESNext"` / `"moduleResolution": "Bundler"` — the correct minimal fix for a project where `ts-jest` handles all transpilation and there is no `tsc` build step consuming Node-loaded JS. A JSONC comment documents the rationale and the migration path if a Node-consumed build is added in the future.

Closes #190