### PR TITLE
fix: quote and broaden Prettier format script glob

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,7 @@
 **/node_modules
 **/dist
 coverage
+.worktrees
+wwwroot
+Pages
+pnpm-lock.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ A configurable mock OIDC/OAuth2 server for development and testing, built on Due
 ```bash
 pnpm install                                              # install all workspace dependencies
 pnpm lint                                                 # ESLint on all TS files
-pnpm format                                               # Prettier --write on all TS files
+pnpm format                                               # Prettier --write on all JS/TS/JSON/YAML/MD files
 pnpm --filter e2e exec playwright install --with-deps chromium  # install Playwright browser
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "tilt:down": "tilt down",
     "tilt:ci": "tilt ci",
     "lint": "eslint .",
-    "format": "prettier --write **/*.ts",
+    "format": "prettier --write \"**/*.{js,ts,json,yaml,yml,md}\"",
     "prepare": "husky"
   },
   "workspaces": [


### PR DESCRIPTION
The `pnpm format` script used an unquoted `**/*.ts` glob that the shell expanded before Prettier saw it — in shells without `globstar`, this missed all files more than one directory deep. The fix quotes the glob so Prettier controls expansion and broadens the extension set to `**/*.{js,ts,json,yaml,yml,md}`, matching lint-staged coverage exactly. `.prettierignore` is extended with `.worktrees`, `wwwroot`, `Pages`, and `pnpm-lock.yaml` so the broader glob does not recurse into sibling worktrees or vendored assets.

**Known follow-up:** Three files are already out of Prettier sync (`.vscode/launch.json`, `.vscode/tasks.json`, `e2e/config/server-options.json`). A separate PR should run `pnpm format` and commit those changes to keep the scope of this fix reviewable in isolation.

Closes #188