### PR TITLE
ci(security): add Trivy vulnerability scan before GHCR push

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -82,6 +82,16 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.get_version.outputs.version-without-v }}-test
 
+      - name: Scan Docker image for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock:${{ steps.get_version.outputs.version-without-v }}-test
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: 'true'
+          severity: 'CRITICAL,HIGH'
+          vuln-type: 'os,library'
+
       - name: Build and push new docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -91,6 +91,15 @@ jobs:
           ignore-unfixed: 'true'
           severity: 'CRITICAL,HIGH'
           vuln-type: 'os,library'
+          output: 'trivy-results.txt'
+
+      - name: Upload vulnerability scan report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: trivy-vulnerability-report
+          path: trivy-results.txt
+          retention-days: 30
 
       - name: Build and push new docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
The tag.yaml release pipeline had no vulnerability gate — a Docker image containing known-vulnerable OS packages or .NET dependencies could be silently published to GHCR. This adds a Trivy scan step (SHA-pinned to v0.36.0) that fails the workflow on CRITICAL or HIGH CVEs, blocking the push. Scan reports are uploaded as workflow artifacts (30-day retention) for post-mortem when a release is blocked. The scan targets the locally-loaded test image, ensuring no extra registry pull and no race condition between the scan target and the push target.

Closes #195