### PR TITLE
chore(ci): pin third-party GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Cache Tilt binary
         id: cache-tilt
@@ -39,9 +39,9 @@ jobs:
         run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -13,10 +13,10 @@ jobs:
     name: Build and Push Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -24,22 +24,22 @@ jobs:
 
       - id: get_version
         name: Format docker image tag
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@169bf498b5cdd7ef6804e4411eefbdab319aa503 # v2.1.0
 
       - id: repository_owner
         name: Format repository owner
-        uses: ASzc/change-string-case-action@v6
+        uses: ASzc/change-string-case-action@d0603cd0a7dd490be678164909f65c7737470a7f # v6
         with:
           string: ${{ github.repository_owner }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           load: true
           context: ./src
@@ -64,9 +64,9 @@ jobs:
         run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -102,7 +102,7 @@ jobs:
           retention-days: 30
 
       - name: Build and push new docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           push: true
           context: ./src
@@ -127,13 +127,13 @@ jobs:
       NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       dotnet-version: '8.0'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download UI
         run: ./getui.sh
 
       - name: Setup .NET Core SDK ${{ env.dotnet-version }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: ${{ env.dotnet-version }}
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
@@ -143,7 +143,7 @@ jobs:
 
       - id: get_version
         name: Format nuget package version
-        uses: battila7/get-version-action@v2
+        uses: battila7/get-version-action@169bf498b5cdd7ef6804e4411eefbdab319aa503 # v2.1.0
 
       - name: Build Nuget package
         run: |


### PR DESCRIPTION
Third-party GitHub Actions in `pr.yaml` and `tag.yaml` were referenced by mutable version tags (e.g., `@v4`), which can be re-pointed by upstream maintainers and exploited in supply-chain attacks to inject code into CI runs that hold `GITHUB_TOKEN` and registry credentials. This change pins all 16 third-party Action references to their full 40-character commit SHAs, with trailing `# vX.Y.Z` comments for readability, making every CI dependency reference immutable.

Closes #193