### PR TITLE
chore: configure Dependabot for npm, NuGet, Docker, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: npm
+    directory: /e2e
+    schedule:
+      interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: nuget
+    directory: /src
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /src
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/e2e/tests/custom-endpoints/user-management.spec.ts
+++ b/e2e/tests/custom-endpoints/user-management.spec.ts
@@ -100,15 +100,15 @@ describe('User management', () => {
       sub: expect.any(String),
       name: expect.any(String),
       email: expect.any(String),
-      ['some-custom-identity-user-claim']: expect.any(String) as unknown,
+      ['some-custom-identity-user-claim']: expect.any(String),
     });
   }, 10000);
 
   test('Introspection Endpoint', async () => {
     await introspectEndpoint(token, 'some-app', {
       sub: expect.any(String),
-      ['some-app-user-custom-claim']: expect.any(String) as unknown,
-      ['some-app-scope-1-custom-user-claim']: expect.any(String) as unknown,
+      ['some-app-user-custom-claim']: expect.any(String),
+      ['some-app-scope-1-custom-user-claim']: expect.any(String),
     });
   });
 });


### PR DESCRIPTION
No automated dependency updates were configured for this repository. This adds `.github/dependabot.yml` with weekly Dependabot schedules for npm (root workspace and the `e2e` pnpm workspace), NuGet, Docker (configured at `/src` where the Dockerfile lives), and GitHub Actions. Dev-dependencies are grouped into a single PR per npm workspace to reduce review noise.

Closes #198