### PR TITLE
ci: add SBOM and build provenance attestation to docker image

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -12,6 +12,11 @@ jobs:
   build_push_docker:
     name: Build and Push Docker image
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      packages: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -68,7 +73,8 @@ jobs:
         env:
           IMAGE_TAG: ${{ steps.get_version.outputs.version-without-v }}-test
 
-      - name: Build and push new docker image
+      - id: build_push
+        name: Build and push new docker image
         uses: docker/build-push-action@v6
         with:
           push: true
@@ -80,6 +86,30 @@ jobs:
             ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock:${{ steps.get_version.outputs.version-without-v }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock:${{ steps.get_version.outputs.version-without-v }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: true
+          upload-artifact-retention: 90
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock
+          subject-digest: ${{ steps.build_push.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/oidc-server-mock
+          subject-digest: ${{ steps.build_push.outputs.digest }}
+          push-to-registry: true
 
   build_push_nuget:
     name: Build and Push Nuget package

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -87,6 +87,7 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
 
+        # Note: SBOM covers the amd64 variant only (Syft limitation with a single image: reference on ubuntu-latest).
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
@@ -96,6 +97,7 @@ jobs:
           upload-artifact: true
           upload-artifact-retention: 90
 
+        # Note: actions/attest-sbom v4 is a deprecated wrapper around actions/attest; functional, migrate separately.
       - name: Attest SBOM
         uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
@@ -104,6 +106,7 @@ jobs:
           sbom-path: sbom.spdx.json
           push-to-registry: true
 
+        # Note: actions/attest-build-provenance v4 is a deprecated wrapper around actions/attest; functional, migrate separately.
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:

--- a/e2e/tests/custom-endpoints/user-management.spec.ts
+++ b/e2e/tests/custom-endpoints/user-management.spec.ts
@@ -100,15 +100,15 @@ describe('User management', () => {
       sub: expect.any(String),
       name: expect.any(String),
       email: expect.any(String),
-      ['some-custom-identity-user-claim']: expect.any(String) as unknown,
+      ['some-custom-identity-user-claim']: expect.any(String),
     });
   }, 10000);
 
   test('Introspection Endpoint', async () => {
     await introspectEndpoint(token, 'some-app', {
       sub: expect.any(String),
-      ['some-app-user-custom-claim']: expect.any(String) as unknown,
-      ['some-app-scope-1-custom-user-claim']: expect.any(String) as unknown,
+      ['some-app-user-custom-claim']: expect.any(String),
+      ['some-app-scope-1-custom-user-claim']: expect.any(String),
     });
   });
 });


### PR DESCRIPTION
Docker images published to GHCR had no SBOM or build provenance attestation, leaving consumers unable to verify image integrity or inspect the dependency tree. This adds SBOM generation (SPDX-JSON, uploaded as a 90-day workflow artifact and attached as a registry-side OCI attestation) and SLSA build provenance attestation to the \`build_push_docker\` job. Published images are now verifiable with \`gh attestation verify --owner soluto oci://ghcr.io/soluto/oidc-server-mock:<version>\`. All three new action references are SHA-pinned with version comments.

Closes #197